### PR TITLE
feat: Use husky to manage git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
-#!/bin/sh
 pnpm check
 pnpm stylelint

--- a/README.md
+++ b/README.md
@@ -38,15 +38,13 @@ Other handy scripts:
 | `pnpm stylelint` | Lint the CSS |
 | `pnpm stylelint:fix` | Lint the CSS and autofix what it can |
 
-### Git hooks
-
-A `pre-push` hook runs `pnpm check` before any push to catch type errors before they hit CI. It's wired up automatically when you run `pnpm install`.
-
 ## Deployment
 
 The site is deployed on [Cloudflare Workers](https://workers.cloudflare.com/) via `wrangler`. If you're forking this for your own use, you'll need your own Cloudflare account and a `wrangler.jsonc` configured for it.
 
 ## CI/CD
+
+This site uses [Husky](https://typicode.github.io/husky/) to manage pre-commit hooks.
 
 A [GitHub Actions](https://github.com/features/actions) workflow runs on every push and pull request to `main`. It builds the site and validates the HTML — no broken markup sneaks through unnoticed.
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check": "astro check",
     "dev": "astro dev",
     "html-validate": "pnpm build && pnpm exec html-validate dist/*.html",
-    "prepare": "git config core.hooksPath .git-hooks && chmod +x .git-hooks/*",
+    "prepare": "husky",
     "preview": "astro preview",
     "stylelint": "stylelint \"src/**/*.{css,astro}\"",
     "stylelint:fix": "stylelint \"src/**/*.{css,astro}\" --fix"
@@ -30,6 +30,7 @@
   "devDependencies": {
     "cssnano": "^7.1.2",
     "html-validate": "^10.9.0",
+    "husky": "^9.1.7",
     "stylelint": "^17.4.0",
     "stylelint-config-html": "^1.1.0",
     "stylelint-config-standard": "^40.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       html-validate:
         specifier: ^10.9.0
         version: 10.9.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       stylelint:
         specifier: ^17.4.0
         version: 17.4.0(typescript@5.9.3)
@@ -1439,6 +1442,11 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
@@ -4037,6 +4045,8 @@ snapshots:
       entities: 4.5.0
 
   http-cache-semantics@4.2.0: {}
+
+  husky@9.1.7: {}
 
   ignore@7.0.5: {}
 


### PR DESCRIPTION
Was previously managing git hooks manually because I wanted to keep dev dependencies to a minimum. But after some more research husky is lightweight and should be easier to manage, so I'm giving it a go.