### PR TITLE
chore: Use an import path prefix

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,6 @@
 ---
 
-import Container from './Container.astro';
+import Container from '@/components/Container.astro';
 
 const socialLinks = [
   {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
-import ThemeToggle from './ThemeToggle.astro';
+import Container from '@/components/Container.astro';
+import ThemeToggle from '@/components/ThemeToggle.astro';
 
 const currentPath = Astro.url.pathname;
 const topLevelPath = currentPath.split('/')[1];
@@ -17,6 +18,7 @@ const navItems = [
 ---
 
 <header class="region">
+  <Container>
   <div class="cluster">
     <nav aria-label="Main Navigation">
       <ul class="cluster">
@@ -29,6 +31,7 @@ const navItems = [
     </nav>
     <ThemeToggle />
   </div>
+  </Container>
 </header>
 
 <style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import '../styles/global.css';
+import '@/styles/global.css';
 
 import { Font } from 'astro:assets';
 
@@ -34,7 +34,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
     <meta property="og:site_name" content="Scott McCracken" />
     <link rel="manifest" href="/manifest.json" />
     <script>
-      import "../scripts/theme-toggle.js";
+      import "@/scripts/theme-toggle.js";
     </script>
     <title>{title}</title>
   </head>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,7 +1,7 @@
 ---
-import Footer from '../components/Footer.astro';
-import Header from '../components/Header.astro';
-import BaseLayout from './BaseLayout.astro';
+import Footer from '@/components/Footer.astro';
+import Header from '@/components/Header.astro';
+import BaseLayout from '@/layouts/BaseLayout.astro';
 
 interface Props {
   title: string;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
-import Container from '../components/Container.astro';
-import PageLayout from '../layouts/PageLayout.astro';
+import Container from '@/components/Container.astro';
+import PageLayout from '@/layouts/PageLayout.astro';
 ---
 
 <PageLayout title="Page Not Found" description="Oops! This page could not be found and it's most likely my fault.">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,7 +1,7 @@
 ---
-import Container from 'src/components/Container.astro';
-import TitleBlock from 'src/components/TitleBlock.astro';
-import PageLayout from '../layouts/PageLayout.astro';
+import Container from '@/components/Container.astro';
+import TitleBlock from '@/components/TitleBlock.astro';
+import PageLayout from '@/layouts/PageLayout.astro';
 
 const timelineItems = [
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
-import Container from '../components/Container.astro';
-import PageLayout from '../layouts/PageLayout.astro';
+import Container from '@/components/Container.astro';
+import PageLayout from '@/layouts/PageLayout.astro';
 ---
 
 <PageLayout

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
     "esModuleInterop": true,
     "module": "ES6",
     "target": "ES6",


### PR DESCRIPTION
Keep imports cleaner so I don't have to guess relative path depths