### PR TITLE
fix: Theme toggle CSS rule not globally scoped

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -66,19 +66,11 @@
 
     & > :is(.moon, .sun) {
       fill: var(--icon-fill);
-
-      .theme-toggle:is(:hover, :focus-visible) > & {
-        fill: var(--icon-fill-hover);
-      }
     }
 
     & > .sun-beams {
       stroke: var(--icon-fill);
       stroke-width: 2px;
-
-      .theme-toggle:is(:hover, :focus-visible) & {
-        stroke: var(--icon-fill-hover);
-      }
     }
 
     [data-theme="dark"] & {
@@ -128,5 +120,13 @@
         }
       }
     }
+  }
+
+  .theme-toggle:is(:hover, :focus-visible) > .sun-and-moon > :is(.moon, .sun) {
+    fill: var(--icon-fill-hover);
+  }
+
+  .theme-toggle:is(:hover, :focus-visible) > .sun-and-moon > .sun-beams {
+    stroke: var(--icon-fill-hover);
   }
 </style>


### PR DESCRIPTION
Fix vite minify css syntax issue Needed `:global` inside the component css to take advantage of the data-theme selector


