### PR TITLE
Add minimum release age for package updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.2.0
         with:
-          version: 10
+          version: 11.15.1
 
       - name: Use Node.js 22
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -20,13 +20,7 @@
     "astro": "^6.1.6",
     "typescript": "^5.9.3"
   },
-  "pnpm": {
-    "overrides": {
-      "rollup": "^4.59.0",
-      "lodash": "^4.17.23",
-      "svgo": "^4.0.1"
-    }
-  },
+  "packageManager": "pnpm@11.15.1",
   "devDependencies": {
     "@biomejs/biome": "2.5.4",
     "cssnano": "^7.1.3",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+minimumReleaseAge: 4320
+minimumReleaseAgeStrict: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,13 @@
 minimumReleaseAge: 4320
 minimumReleaseAgeStrict: true
+minimumReleaseAgeExclude:
+  - fast-uri@3.1.4
+
+overrides:
+  rollup: "^4.59.0"
+  lodash: "^4.17.23"
+  svgo: "^4.0.1"
+
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Slow down supply chain attacks with a minimum release age on package updates