### PR TITLE
fix: Wider hero image

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,5 @@
 minimumReleaseAge: 4320
 minimumReleaseAgeStrict: true
-minimumReleaseAgeExclude:
-  - fast-uri@3.1.4
 
 overrides:
   rollup: "^4.59.0"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -208,6 +208,7 @@ const featuredProjects = [
 <style>
   .hero {
     --region-space: var(--space-xl-2xl);
+    --sidebar-width: 30rem;
   }
 
   .hero__title {


### PR DESCRIPTION
- Adjust hero sidebar width on homepage
- Remove min release age override since we're out of the 3 day window now